### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ To build for iOS, add the `publishableKey` preference tag to the `config.xml` fi
 ```xml
 <preference name="publishableKey" value="INSERT-PUBLIC-KEY-HERE" />
 ```
-###Build the your app
+###Build your app
 Before you try to run your app, you should build it first to install all native dependencies in android
 ```
 cordova build ios|android

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ To build for iOS, add the `publishableKey` preference tag to the `config.xml` fi
 <preference name="publishableKey" value="INSERT-PUBLIC-KEY-HERE" />
 ```
 
+
+
 ### Manually
 You'd better use the CLI, but here goes:
 
@@ -112,6 +114,11 @@ To build for iOS, add the `publishableKey` preference tag to the `config.xml` fi
 
 ```xml
 <preference name="publishableKey" value="INSERT-PUBLIC-KEY-HERE" />
+```
+###Build the your app
+Before you try to run your app, you should build it first to install all native dependencies in android
+```
+cordova build ios|android
 ```
 
 ## 3. Usage


### PR DESCRIPTION
Running `ionic run android` failed and throws this error 

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'android'.
> Could not resolve all dependencies for configuration ':_debugCompile'.
   > Could not resolve co.paystack.android:paystack:1.2.0.
     Required by:
         :android:unspecified
      > Could not GET 'https://repo1.maven.org/maven2/co/paystack/android/paystack/1.2.0/paystack-1.2.0.pom'.
         > repo1.maven.org
      > Could not GET 'https://dl.bintray.com/paystack/maven/co/paystack/android/paystack/1.2.0/paystack-1.2.0.pom'.
         > dl.bintray.com
      > Could not GET 'https://oss.sonatype.org/content/repositories/snapshots/co/paystack/android/paystack/1.2.0/paystack-1.2.0.pom'.
         > oss.sonatype.org

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

```

Building the app first before trying to run it fixes it.
