### PR TITLE
fix(android): prevent plugin from overwriting app' version number

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,8 +5,6 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 1
-        versionName "1.0"
     }
 
     buildTypes {


### PR DESCRIPTION
This fixes cases where plugin prevents the app from using version number specified in config.xml